### PR TITLE
Wrong "new artcle" judgment at first interval, due to missing initialization of title.

### DIFF
--- a/src/watcher.coffee
+++ b/src/watcher.coffee
@@ -53,6 +53,7 @@ class Watcher extends EventEmitter
       request @feedUrl,(err,articles)=>
         return callback new Error(err),null if err? and callback?
         @lastPubDate = articles[articles.length-1].pubDate / 1000
+        @lastPubTitle = articles[articles.length-1].title
         @timer = @watch()
         return callback null,articles if callback?
 


### PR DESCRIPTION
titleの初期化忘れのせいで、初回のinterval時に間違った新着判定がなされることがある。
